### PR TITLE
fix: Windows can't deal with aux files bua bua

### DIFF
--- a/test/integration/microservice_boilerplate/db_test.clj
+++ b/test/integration/microservice_boilerplate/db_test.clj
@@ -1,7 +1,7 @@
 (ns integration.microservice-boilerplate.db-test
   (:require [clojure.test :as clojure.test]
             [com.stuartsierra.component :as component]
-            [integration.microservice-boilerplate.aux :as aux]
+            [integration.microservice-boilerplate.util :as util]
             [microservice-boilerplate.db :as db]
             [parenthesin.components.config :as components.config]
             [parenthesin.components.database :as components.database]
@@ -22,8 +22,8 @@
 
 (defflow
   flow-integration-db-test
-  {:init (aux/start-system! create-and-start-components!)
-   :cleanup aux/stop-system!
+  {:init (util/start-system! create-and-start-components!)
+   :cleanup util/stop-system!
    :fail-fast? true}
   (flow "creates a table, insert data and checks return in the database"
     [database (state-flow.api/get-state :database)]

--- a/test/integration/microservice_boilerplate/util.clj
+++ b/test/integration/microservice_boilerplate/util.clj
@@ -1,4 +1,4 @@
-(ns integration.microservice-boilerplate.aux
+(ns integration.microservice-boilerplate.util
   (:require [com.stuartsierra.component :as component]
             [parenthesin.logs :as logs]
             [parenthesin.migrations :as migrations]

--- a/test/integration/parenthesin/database_test.clj
+++ b/test/integration/parenthesin/database_test.clj
@@ -1,7 +1,7 @@
 (ns integration.parenthesin.database-test
   (:require [clojure.test :as clojure.test]
-            [integration.parenthesin.aux :as aux]
-            [integration.parenthesin.aux.database :as aux.database]
+            [integration.parenthesin.util :as util]
+            [integration.parenthesin.util.database :as util.database]
             [schema.test :as schema.test]
             [state-flow.api :refer [defflow]]
             [state-flow.assertions.matcher-combinators :refer [match?]]
@@ -11,19 +11,19 @@
 
 (defflow
   flow-integration-database-test
-  {:init aux/start-system!
-   :cleanup aux/stop-system!
+  {:init util/start-system!
+   :cleanup util/stop-system!
    :fail-fast? true}
   (flow "creates a table, insert data and checks return in the database"
-    (aux.database/execute! ["create table if not exists address (
+    (util.database/execute! ["create table if not exists address (
                                id serial primary key,
                                name varchar(32),
                                email varchar(255))"])
 
-    (aux.database/execute! ["insert into address(name,email)
+    (util.database/execute! ["insert into address(name,email)
                                values('Sam Campos de Milho','sammilhoso@email.com')"])
 
     (match? [#:address{:id 1
                        :name "Sam Campos de Milho"
                        :email "sammilhoso@email.com"}]
-            (aux.database/execute! ["select * from address"]))))
+            (util.database/execute! ["select * from address"]))))

--- a/test/integration/parenthesin/system_test.clj
+++ b/test/integration/parenthesin/system_test.clj
@@ -1,9 +1,9 @@
 (ns integration.parenthesin.system-test
   (:require [clojure.test :as clojure.test]
-            [integration.parenthesin.aux :as aux]
-            [integration.parenthesin.aux.database :as aux.database]
-            [integration.parenthesin.aux.http :as aux.http]
-            [integration.parenthesin.aux.webserver :as aux.webserver]
+            [integration.parenthesin.util :as aux]
+            [integration.parenthesin.util.database :as util.database]
+            [integration.parenthesin.util.http :as util.http]
+            [integration.parenthesin.util.webserver :as util.webserver]
             [parenthesin.components.database :as components.database]
             [parenthesin.components.http :as components.http]
             [schema.core :as s]
@@ -56,17 +56,17 @@
   (flow "should interact with system"
 
     (flow "prepare system with http-out mocks and creating tables"
-      (aux.http/set-http-out-responses! {"http://coinbase.org" {:body {:rate 35000.0M}
+      (util.http/set-http-out-responses! {"http://coinbase.org" {:body {:rate 35000.0M}
                                                                 :status 200}})
 
-      (aux.database/execute! ["create table if not exists wallet (
+      (util.database/execute! ["create table if not exists wallet (
                                   id serial primary key,
                                   price decimal)"])
 
       (flow "should insert deposit into wallet"
         (match? {:status 201
                  :body {:usd 70000.0}}
-                (aux.webserver/request! {:method :post
+                (util.webserver/request! {:method :post
                                          :uri    "/wallet/deposit"
                                          :body   {:btc 2M}})))
 
@@ -74,5 +74,5 @@
         (match? {:status 200
                  :body [{:id 1
                          :amount 70000.0}]}
-                (aux.webserver/request! {:method :get
+                (util.webserver/request! {:method :get
                                          :uri    "/wallet/list"}))))))

--- a/test/integration/parenthesin/util.clj
+++ b/test/integration/parenthesin/util.clj
@@ -1,4 +1,4 @@
-(ns integration.parenthesin.aux
+(ns integration.parenthesin.util
   (:require [com.stuartsierra.component :as component]
             [parenthesin.components.config :as components.config]
             [parenthesin.components.database :as components.database]

--- a/test/integration/parenthesin/util/database.clj
+++ b/test/integration/parenthesin/util/database.clj
@@ -1,4 +1,4 @@
-(ns integration.parenthesin.aux.database
+(ns integration.parenthesin.util.database
   (:require [parenthesin.components.database :as db]
             [state-flow.api :as state-flow.api]
             [state-flow.core :as state-flow :refer [flow]]))

--- a/test/integration/parenthesin/util/http.clj
+++ b/test/integration/parenthesin/util/http.clj
@@ -1,4 +1,4 @@
-(ns integration.parenthesin.aux.http
+(ns integration.parenthesin.util.http
   (:require [parenthesin.components.http :as components.http]
             [state-flow.api :as state-flow.api]
             [state-flow.core :as state-flow :refer [flow]]))

--- a/test/integration/parenthesin/util/webserver.clj
+++ b/test/integration/parenthesin/util/webserver.clj
@@ -1,4 +1,4 @@
-(ns integration.parenthesin.aux.webserver
+(ns integration.parenthesin.util.webserver
   (:require [cheshire.core :as json]
             [clojure.string :as string]
             [io.pedestal.test :as pt]

--- a/test/integration/parenthesin/webserver_test.clj
+++ b/test/integration/parenthesin/webserver_test.clj
@@ -1,7 +1,7 @@
 (ns integration.parenthesin.webserver-test
   (:require [clojure.test :as clojure.test]
-            [integration.parenthesin.aux :as aux]
-            [integration.parenthesin.aux.webserver :as aux.webserver]
+            [integration.parenthesin.util :as util]
+            [integration.parenthesin.util.webserver :as util.webserver]
             [schema.core :as s]
             [schema.test :as schema.test]
             [state-flow.api :refer [defflow]]
@@ -27,19 +27,19 @@
 
 (defflow
   flow-integration-webserver-test
-  {:init (partial aux/start-system! test-routes)
-   :cleanup aux/stop-system!
+  {:init (partial util/start-system! test-routes)
+   :cleanup util/stop-system!
    :fail-fast? true}
   (flow "should interact test-routes"
     (flow "should sum the get params x & y via get"
       (match? {:status 200
                :body {:total 7}}
-              (aux.webserver/request! {:method  :get
+              (util.webserver/request! {:method  :get
                                        :uri     (str "/plus?x=" 3 "&y=" 4)})))
     (flow "should sum the body x & y via post"
       (match? {:status 200
                :body {:total 7}}
-              (aux.webserver/request! {:method  :post
+              (util.webserver/request! {:method  :post
                                        :uri     "/plus"
                                        :body    {:x 4
                                                  :y 3}})))))


### PR DESCRIPTION
https://www.howtogeek.com/fyi/windows-10-still-wont-let-you-use-these-file-names-reserved-in-1974
![shibs](https://user-images.githubusercontent.com/1683898/124209842-af074f80-dac0-11eb-8e7b-946c2f3651c8.jpg)
