### PR TITLE
fix: Remove vector wrap from log messages

### DIFF
--- a/src/parenthesin/logs.clj
+++ b/src/parenthesin/logs.clj
@@ -9,5 +9,5 @@
     {:println
      (core-appenders/println-appender {:stream stream})}}))
 
-(defn log [level & args]
-  (timbre/log level args))
+(defmacro log [level & args]
+  `(timbre/log! ~level :p ~args ~{:?line (:line (meta &form))}))


### PR DESCRIPTION
The definition of `log` was copied from timbre source code[1]. This should keep a small abstraction over the logging framework while fixing the vector wrap and formatting of arguments.

[1]: https://github.com/ptaoussanis/timbre/blob/5d959191e2790f1c4aa1b866b6f0812c0c70c9d9/src/taoensso/timbre.cljc#L840
---
Here is a preview of the before `log` and after `log'`:
<img width="1439" alt="image (3)" src="https://user-images.githubusercontent.com/49727703/202037279-3856f1ab-5b9b-4ab8-aa01-14c2243d88ea.png">
(for some reason the encoding doesn't seem to be correct in the repl, but it does render without any issues in my terminal (running application))

Note: I do not like macros, and I know you are also not a big fan, but I did not find a way around them since timbre/log is a macro itself.

Please let me know if you would like me to change anything.