### PR TITLE
refactor: move to kraken

### DIFF
--- a/src/microservice_boilerplate/adapters.clj
+++ b/src/microservice_boilerplate/adapters.clj
@@ -23,9 +23,10 @@
       (.format (DateTimeFormatter/ofPattern str-format))))
 
 (s/defn wire->usd-price  :- s/Num
-  [wire :- schemas.wire-out/CoinDeskResponse]
+  [wire :- schemas.wire-out/KrakenResponse]
   (-> wire
-      (get-in [:bpi :USD :rate_float])
+      (get-in [:result :XXBTZUSD :c])
+      first
       bigdec))
 
 (s/defn ^:private wire-in->db  :- schemas.db/WalletTransaction

--- a/src/microservice_boilerplate/ports/http_out.clj
+++ b/src/microservice_boilerplate/ports/http_out.clj
@@ -6,7 +6,7 @@
 
 (s/defn get-btc-usd-price :- s/Num
   [http :- schemas.types/HttpComponent]
-  (->> {:url "https://api.coindesk.com/v1/bpi/currentprice.json"
+  (->> {:url "https://api.kraken.com/0/public/Ticker?pair=XBTUSD"
         :as :json
         :method :get}
        (components.http/request http)

--- a/src/microservice_boilerplate/schemas/wire_out.clj
+++ b/src/microservice_boilerplate/schemas/wire_out.clj
@@ -1,8 +1,8 @@
 (ns microservice-boilerplate.schemas.wire-out
   (:require [schema.core :as s]))
 
-(s/defschema CoinDeskResponse
-  {:bpi {:USD {:rate_float s/Num
-               s/Any s/Any}
-         s/Any s/Any}
+(s/defschema KrakenResponse
+  {:result {:XXBTZUSD {:c [s/Num]
+                       s/Any s/Any}
+            s/Any s/Any}
    s/Any s/Any})

--- a/test/integration/microservice_boilerplate/wallet_test.clj
+++ b/test/integration/microservice_boilerplate/wallet_test.clj
@@ -37,8 +37,8 @@
   (flow "should interact with system"
 
     (flow "prepare system with http-out mocks"
-      (state-flow.http/set-http-out-responses! {"https://api.coindesk.com/v1/bpi/currentprice.json"
-                                                {:body {:bpi {:USD {:rate_float 30000.00}}}
+      (state-flow.http/set-http-out-responses! {"https://api.kraken.com/0/public/Ticker?pair=XBTUSD"
+                                                {:body {:result {:XXBTZUSD {:c [30000.00 0.01]}}}
                                                  :status 200}})
 
       (flow "should insert deposit into wallet"

--- a/test/unit/microservice_boilerplate/adapters_test.clj
+++ b/test/unit/microservice_boilerplate/adapters_test.clj
@@ -20,27 +20,23 @@
            (adapters/inst->utc-formated-string #inst "1987-02-10T09:38:43.000Z"
                                                "yyyy-MM-dd hh:mm:ss")))))
 
-(def coindesk-response-fixture
-  {:time {:updated "Jun 26, 2021 20:06:00 UTC"
-          :updatedISO "2021-06-26T20:06:00+00:00"
-          :updateduk "Jun 26, 2021 at 21:06 BST"}
-   :bpi {:USD
-         {:code "USD"
-          :symbol "&#36;"
-          :rate "31,343.9261"
-          :description "United States Dollar"
-          :rate_float 31343.9261}
-         :GBP
-         {:code "GBP"
-          :symbol "&pound;"
-          :rate "22,573.9582"
-          :description "British Pound Sterling"
-          :rate_float 22573.9582}}})
+(def kraken-response-fixture
+  {:error []
+   :result {:XXBTZUSD
+            {:v [152.11586649 2142.49260838]
+             :o 115990.20000
+             :l [115212.50000 11060 0.00000]
+             :c [116279.00000 0.01177482]
+             :h [116282.30000 116800.00000]
+             :b [116279.00000 4 4.000]
+             :t [4377 51302]
+             :p [115713.81470 113745.05028]
+             :a [116279.10000 1 1.000]}}})
 
 (deftest wire->usd-price-test
-  (testing "should adapt coindesk response into a number"
-    (is (match? 31343.9261M
-                (adapters/wire->usd-price coindesk-response-fixture)))))
+  (testing "should adapt kraken response into a number"
+    (is (match? 116279M
+                (adapters/wire->usd-price kraken-response-fixture)))))
 
 (defspec wire-in-db-test 50
   (properties/for-all [id (g/generator s/Uuid)


### PR DESCRIPTION
This PR tries to refactor boilerplate:
- Using Kraken instead of CoinDesk API (due to unavailability to public API without authentication)
- This implementation uses [Ticker Information](https://docs.kraken.com/api/docs/rest-api/get-ticker-information)